### PR TITLE
Added ConcurrentDictionary Seamaphore to block concurrent Buy requests until each one fully processes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet test:*)"
+    ]
+  }
+}

--- a/HockeyPickup.Api.Tests/ServicesTests/BuySellServiceTest.cs
+++ b/HockeyPickup.Api.Tests/ServicesTests/BuySellServiceTest.cs
@@ -2850,5 +2850,213 @@ public class BuySellServiceTests
             result.Data.Reason.Should().Be("You must be on the roster to sell your spot");
         }
     }
+    [Fact]
+    public async Task ProcessBuyRequestAsync_ConcurrentBuyers_OnlyOneClaimsTheSell()
+    {
+        // Arrange — unique session ID avoids static-lock contention with other tests
+        var sessionId = 97;
+        var buyer1Id = "concBuyer1";
+        var buyer2Id = "concBuyer2";
+        var sellerId = "concSeller1";
+
+        var buyer1 = CreateTestUser(buyer1Id);
+        var buyer2 = CreateTestUser(buyer2Id);
+        var seller = CreateTestUser(sellerId);
+        var buyer1Response = CreateTestUserResponse(buyer1Id);
+        var buyer2Response = CreateTestUserResponse(buyer2Id);
+        var sellerResponse = CreateTestUserResponse(sellerId);
+
+        var session = CreateTestSessionDetailedResponse(sessionId);
+        session.CurrentRosters = new List<RosterPlayer>
+        {
+            new RosterPlayer
+            {
+                UserId = sellerId, TeamAssignment = TeamAssignment.Light, IsPlaying = true,
+                FirstName = "Test", LastName = "Seller", Email = "seller@test.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 1, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            }
+        };
+
+        var existingSell = new BuySell
+        {
+            BuySellId = 100, SessionId = sessionId, SellerUserId = sellerId, BuyerUserId = null,
+            TeamAssignment = TeamAssignment.Light, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Seller = seller, Session = CreateTestSession(sessionId),
+            CreateByUserId = sellerId, UpdateByUserId = sellerId
+        };
+        var matchedBuySell = new BuySell
+        {
+            BuySellId = 100, SessionId = sessionId, SellerUserId = sellerId, BuyerUserId = buyer1Id,
+            TeamAssignment = TeamAssignment.Light, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Seller = seller, Buyer = buyer1,
+            Session = CreateTestSession(sessionId), CreateByUserId = buyer1Id, UpdateByUserId = buyer1Id
+        };
+        var queuedBuySell = new BuySell
+        {
+            BuySellId = 101, SessionId = sessionId, BuyerUserId = buyer2Id, SellerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Buyer = buyer2, Session = CreateTestSession(sessionId),
+            CreateByUserId = buyer2Id, UpdateByUserId = buyer2Id
+        };
+
+        // The key: first lock-holder finds the sell, second finds nothing (sell already claimed)
+        _mockBuySellRepository.SetupSequence(x => x.FindMatchingSellBuySellAsync(sessionId))
+            .ReturnsAsync(existingSell)
+            .ReturnsAsync((BuySell?) null);
+
+        _userManager.Setup(x => x.FindByIdAsync(buyer1Id)).ReturnsAsync(buyer1);
+        _userManager.Setup(x => x.FindByIdAsync(buyer2Id)).ReturnsAsync(buyer2);
+        _userManager.Setup(x => x.FindByIdAsync(sellerId)).ReturnsAsync(seller);
+        _userManager.Setup(x => x.IsInRoleAsync(It.IsAny<AspNetUser>(), "Admin")).ReturnsAsync(false);
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _mockSessionRepository.Setup(x => x.AddOrUpdatePlayerToRosterAsync(
+            sessionId, It.IsAny<string>(), It.IsAny<TeamAssignment>(),
+            It.IsAny<PositionPreference>(), It.IsAny<int>()))
+            .ReturnsAsync(session);
+
+        _mockBuySellRepository.Setup(x => x.GetUserBuySellsAsync(sessionId, buyer1Id)).ReturnsAsync(new List<BuySell>());
+        _mockBuySellRepository.Setup(x => x.GetUserBuySellsAsync(sessionId, buyer2Id)).ReturnsAsync(new List<BuySell>());
+        _mockBuySellRepository.Setup(x => x.UpdateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>())).ReturnsAsync(matchedBuySell);
+        _mockBuySellRepository.Setup(x => x.CreateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>())).ReturnsAsync(queuedBuySell);
+        _mockBuySellRepository.Setup(x => x.GetQueuePositionAsync(It.IsAny<int>())).ReturnsAsync(1);
+
+        _mockUserRepository.Setup(x => x.GetUserAsync(buyer1Id)).ReturnsAsync(buyer1Response);
+        _mockUserRepository.Setup(x => x.GetUserAsync(buyer2Id)).ReturnsAsync(buyer2Response);
+        _mockUserRepository.Setup(x => x.GetUserAsync(sellerId)).ReturnsAsync(sellerResponse);
+        _mockUserRepository.Setup(x => x.GetDetailedUsersAsync())
+            .ReturnsAsync(new List<UserDetailedResponse> { buyer1Response, buyer2Response });
+
+        _mockConfiguration.Setup(x => x["ServiceBusCommsQueueName"]).Returns("testqueue");
+        _mockConfiguration.Setup(x => x["BaseUrl"]).Returns("https://test.com");
+        _mockServiceBus.Setup(x => x.SendAsync(
+            It.IsAny<ServiceBusCommsMessage>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act — two buyers race to claim the one available sell spot
+        var task1 = _buySellService.ProcessBuyRequestAsync(buyer1Id, new BuyRequest { SessionId = sessionId, Note = "Concurrent buy 1" });
+        var task2 = _buySellService.ProcessBuyRequestAsync(buyer2Id, new BuyRequest { SessionId = sessionId, Note = "Concurrent buy 2" });
+        var results = await Task.WhenAll(task1, task2);
+
+        // Assert — both succeed; the lock ensured only one claimed the sell and one was queued
+        results[0].IsSuccess.Should().BeTrue();
+        results[1].IsSuccess.Should().BeTrue();
+        _mockBuySellRepository.Verify(x => x.UpdateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
+        _mockBuySellRepository.Verify(x => x.CreateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessSellRequestAsync_ConcurrentSellers_OnlyOneClaimsTheBuy()
+    {
+        // Arrange — unique session ID avoids static-lock contention with other tests
+        var sessionId = 98;
+        var seller1Id = "concSeller2";
+        var seller2Id = "concSeller3";
+        var buyerId = "concBuyer3";
+
+        var seller1 = CreateTestUser(seller1Id);
+        var seller2 = CreateTestUser(seller2Id);
+        var buyer = CreateTestUser(buyerId);
+        var seller1Response = CreateTestUserResponse(seller1Id);
+        var seller2Response = CreateTestUserResponse(seller2Id);
+        var buyerResponse = CreateTestUserResponse(buyerId);
+
+        var session = CreateTestSessionDetailedResponse(sessionId);
+        session.CurrentRosters = new List<RosterPlayer>
+        {
+            new RosterPlayer
+            {
+                UserId = seller1Id, TeamAssignment = TeamAssignment.Light, IsPlaying = true,
+                FirstName = "Test", LastName = "Seller1", Email = "seller1@test.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 1, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            },
+            new RosterPlayer
+            {
+                UserId = seller2Id, TeamAssignment = TeamAssignment.Dark, IsPlaying = true,
+                FirstName = "Test", LastName = "Seller2", Email = "seller2@test.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 2, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            }
+        };
+
+        var existingBuy = new BuySell
+        {
+            BuySellId = 200, SessionId = sessionId, BuyerUserId = buyerId, SellerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Buyer = buyer, Session = CreateTestSession(sessionId),
+            CreateByUserId = buyerId, UpdateByUserId = buyerId
+        };
+        var matchedSellBuySell = new BuySell
+        {
+            BuySellId = 200, SessionId = sessionId, BuyerUserId = buyerId, SellerUserId = seller1Id,
+            TeamAssignment = TeamAssignment.Light, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Buyer = buyer, Seller = seller1,
+            Session = CreateTestSession(sessionId), CreateByUserId = seller1Id, UpdateByUserId = seller1Id
+        };
+        var queuedSellBuySell = new BuySell
+        {
+            BuySellId = 201, SessionId = sessionId, SellerUserId = seller2Id, BuyerUserId = null,
+            TeamAssignment = TeamAssignment.Dark, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Seller = seller2, Session = CreateTestSession(sessionId),
+            CreateByUserId = seller2Id, UpdateByUserId = seller2Id
+        };
+
+        // The key: first lock-holder finds the buy, second finds nothing (buy already claimed)
+        _mockBuySellRepository.SetupSequence(x => x.FindMatchingBuyBuySellAsync(sessionId))
+            .ReturnsAsync(existingBuy)
+            .ReturnsAsync((BuySell?) null);
+
+        _userManager.Setup(x => x.FindByIdAsync(seller1Id)).ReturnsAsync(seller1);
+        _userManager.Setup(x => x.FindByIdAsync(seller2Id)).ReturnsAsync(seller2);
+        _userManager.Setup(x => x.FindByIdAsync(buyerId)).ReturnsAsync(buyer);
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _mockSessionRepository.Setup(x => x.UpdatePlayerStatusAsync(
+            sessionId, It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .ReturnsAsync(session);
+        _mockSessionRepository.Setup(x => x.AddOrUpdatePlayerToRosterAsync(
+            sessionId, It.IsAny<string>(), It.IsAny<TeamAssignment>(),
+            It.IsAny<PositionPreference>(), It.IsAny<int>()))
+            .ReturnsAsync(session);
+
+        _mockBuySellRepository.Setup(x => x.GetUserBuySellsAsync(sessionId, seller1Id)).ReturnsAsync(new List<BuySell>());
+        _mockBuySellRepository.Setup(x => x.GetUserBuySellsAsync(sessionId, seller2Id)).ReturnsAsync(new List<BuySell>());
+        _mockBuySellRepository.Setup(x => x.UpdateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>())).ReturnsAsync(matchedSellBuySell);
+        _mockBuySellRepository.Setup(x => x.CreateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>())).ReturnsAsync(queuedSellBuySell);
+        _mockBuySellRepository.Setup(x => x.GetQueuePositionAsync(It.IsAny<int>())).ReturnsAsync(1);
+
+        _mockUserRepository.Setup(x => x.GetUserAsync(seller1Id)).ReturnsAsync(seller1Response);
+        _mockUserRepository.Setup(x => x.GetUserAsync(seller2Id)).ReturnsAsync(seller2Response);
+        _mockUserRepository.Setup(x => x.GetUserAsync(buyerId)).ReturnsAsync(buyerResponse);
+        _mockUserRepository.Setup(x => x.GetDetailedUsersAsync())
+            .ReturnsAsync(new List<UserDetailedResponse> { seller1Response, seller2Response });
+
+        _mockConfiguration.Setup(x => x["ServiceBusCommsQueueName"]).Returns("testqueue");
+        _mockConfiguration.Setup(x => x["BaseUrl"]).Returns("https://test.com");
+        _mockServiceBus.Setup(x => x.SendAsync(
+            It.IsAny<ServiceBusCommsMessage>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act — two sellers race to claim the one available buy spot
+        var task1 = _buySellService.ProcessSellRequestAsync(seller1Id, new SellRequest { SessionId = sessionId, Note = "Concurrent sell 1" });
+        var task2 = _buySellService.ProcessSellRequestAsync(seller2Id, new SellRequest { SessionId = sessionId, Note = "Concurrent sell 2" });
+        var results = await Task.WhenAll(task1, task2);
+
+        // Assert — both succeed; the lock ensured only one claimed the buy and one was queued
+        results[0].IsSuccess.Should().BeTrue();
+        results[1].IsSuccess.Should().BeTrue();
+        _mockBuySellRepository.Verify(x => x.UpdateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
+        _mockBuySellRepository.Verify(x => x.CreateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
+    }
 }
 #pragma warning restore IDE0045 // Convert to conditional expression

--- a/HockeyPickup.Api.Tests/ServicesTests/BuySellServiceTest.cs
+++ b/HockeyPickup.Api.Tests/ServicesTests/BuySellServiceTest.cs
@@ -3058,5 +3058,201 @@ public class BuySellServiceTests
         _mockBuySellRepository.Verify(x => x.UpdateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
         _mockBuySellRepository.Verify(x => x.CreateBuySellAsync(It.IsAny<BuySell>(), It.IsAny<string>()), Times.Once);
     }
+
+    [Fact]
+    public async Task ProcessBuyRequestAsync_TocTouReCheck_Fails_WhenActiveBuyFoundInsideLock()
+    {
+        // Arrange — unique session ID avoids static-lock contention with other tests
+        var sessionId = 104;
+        var userId = "tocTouBuyer1";
+        var user = CreateTestUser(userId);
+        var session = CreateTestSessionDetailedResponse(sessionId);
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+        _userManager.Setup(x => x.IsInRoleAsync(user, "Admin")).ReturnsAsync(false);
+
+        // First call (CanBuyAsync pre-check) returns empty → allowed; second call (inside lock) finds duplicate → rejected
+        var activeBuy = new BuySell
+        {
+            BuySellId = 300, SessionId = sessionId, BuyerUserId = userId, SellerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Buyer = user, Session = CreateTestSession(sessionId),
+            CreateByUserId = userId, UpdateByUserId = userId
+        };
+        _mockBuySellRepository.SetupSequence(x => x.GetUserBuySellsAsync(sessionId, userId))
+            .ReturnsAsync(new List<BuySell>())
+            .ReturnsAsync(new List<BuySell> { activeBuy });
+
+        // Act
+        var result = await _buySellService.ProcessBuyRequestAsync(userId, new BuyRequest { SessionId = sessionId, Note = "test" });
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be("You already have an active Buy for this session");
+    }
+
+    [Fact]
+    public async Task ProcessBuyRequestAsync_TocTouReCheck_Fails_WhenActiveSellFoundInsideLock()
+    {
+        var sessionId = 105;
+        var userId = "tocTouBuyer2";
+        var user = CreateTestUser(userId);
+        var session = CreateTestSessionDetailedResponse(sessionId);
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+        _userManager.Setup(x => x.IsInRoleAsync(user, "Admin")).ReturnsAsync(false);
+
+        // Include a non-matching element first so the lambda evaluates SellerUserId != userId (false branch of &&)
+        var otherUserSell = new BuySell
+        {
+            BuySellId = 400, SessionId = sessionId, SellerUserId = "anotherUser", BuyerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Session = CreateTestSession(sessionId),
+            CreateByUserId = "anotherUser", UpdateByUserId = "anotherUser"
+        };
+        var activeSell = new BuySell
+        {
+            BuySellId = 301, SessionId = sessionId, SellerUserId = userId, BuyerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Seller = user, Session = CreateTestSession(sessionId),
+            CreateByUserId = userId, UpdateByUserId = userId
+        };
+        _mockBuySellRepository.SetupSequence(x => x.GetUserBuySellsAsync(sessionId, userId))
+            .ReturnsAsync(new List<BuySell>())
+            .ReturnsAsync(new List<BuySell> { otherUserSell, activeSell });
+
+        var result = await _buySellService.ProcessBuyRequestAsync(userId, new BuyRequest { SessionId = sessionId, Note = "test" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be("You have an active Sell for this session");
+    }
+
+    [Fact]
+    public async Task ProcessBuyRequestAsync_TocTouReCheck_Fails_WhenUserAppearsOnRosterInsideLock()
+    {
+        var sessionId = 106;
+        var userId = "tocTouBuyer3";
+        var user = CreateTestUser(userId);
+
+        // First GetSessionAsync call (CanBuyAsync): user not on roster → pre-check passes
+        var sessionEmptyRoster = CreateTestSessionDetailedResponse(sessionId);
+        // Second GetSessionAsync call (inside lock): user now on roster → re-check triggers
+        var sessionWithRoster = CreateTestSessionDetailedResponse(sessionId);
+        sessionWithRoster.CurrentRosters = new List<RosterPlayer>
+        {
+            new RosterPlayer
+            {
+                UserId = userId, TeamAssignment = TeamAssignment.Light, IsPlaying = true,
+                FirstName = "Test", LastName = "User", Email = "test@example.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 1, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            }
+        };
+
+        _mockSessionRepository.SetupSequence(x => x.GetSessionAsync(sessionId))
+            .ReturnsAsync(sessionEmptyRoster)
+            .ReturnsAsync(sessionWithRoster);
+        _userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+        _userManager.Setup(x => x.IsInRoleAsync(user, "Admin")).ReturnsAsync(false);
+        _mockBuySellRepository.Setup(x => x.GetUserBuySellsAsync(sessionId, userId))
+            .ReturnsAsync(new List<BuySell>());
+
+        var result = await _buySellService.ProcessBuyRequestAsync(userId, new BuyRequest { SessionId = sessionId, Note = "test" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be("You are already on the roster for this session");
+    }
+
+    [Fact]
+    public async Task ProcessSellRequestAsync_TocTouReCheck_Fails_WhenActiveBuyFoundInsideLock()
+    {
+        var sessionId = 107;
+        var userId = "tocTouSeller1";
+        var user = CreateTestUser(userId);
+        var session = CreateTestSessionDetailedResponse(sessionId);
+        session.CurrentRosters = new List<RosterPlayer>
+        {
+            new RosterPlayer
+            {
+                UserId = userId, TeamAssignment = TeamAssignment.Light, IsPlaying = true,
+                FirstName = "Test", LastName = "User", Email = "test@example.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 1, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            }
+        };
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+
+        var activeBuy = new BuySell
+        {
+            BuySellId = 302, SessionId = sessionId, BuyerUserId = userId, SellerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Buyer = user, Session = CreateTestSession(sessionId),
+            CreateByUserId = userId, UpdateByUserId = userId
+        };
+        _mockBuySellRepository.SetupSequence(x => x.GetUserBuySellsAsync(sessionId, userId))
+            .ReturnsAsync(new List<BuySell>())
+            .ReturnsAsync(new List<BuySell> { activeBuy });
+
+        var result = await _buySellService.ProcessSellRequestAsync(userId, new SellRequest { SessionId = sessionId, Note = "test" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be("You have an active Buy for this session");
+    }
+
+    [Fact]
+    public async Task ProcessSellRequestAsync_TocTouReCheck_Fails_WhenActiveSellFoundInsideLock()
+    {
+        var sessionId = 108;
+        var userId = "tocTouSeller2";
+        var user = CreateTestUser(userId);
+        var session = CreateTestSessionDetailedResponse(sessionId);
+        session.CurrentRosters = new List<RosterPlayer>
+        {
+            new RosterPlayer
+            {
+                UserId = userId, TeamAssignment = TeamAssignment.Light, IsPlaying = true,
+                FirstName = "Test", LastName = "User", Email = "test@example.com",
+                Rating = 1.0m, Position = PositionPreference.Forward,
+                PlayerStatus = PlayerStatus.Regular, PhotoUrl = null!, IsRegular = true,
+                SessionId = sessionId, SessionRosterId = 1, JoinedDateTime = DateTime.UtcNow,
+                CurrentPosition = "Forward", LastBuySellId = null, Preferred = false, PreferredPlus = false
+            }
+        };
+
+        _mockSessionRepository.Setup(x => x.GetSessionAsync(sessionId)).ReturnsAsync(session);
+        _userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+
+        // Include a non-matching element first so the lambda evaluates SellerUserId != userId (false branch of &&)
+        var otherUserSell = new BuySell
+        {
+            BuySellId = 401, SessionId = sessionId, SellerUserId = "anotherUser", BuyerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Session = CreateTestSession(sessionId),
+            CreateByUserId = "anotherUser", UpdateByUserId = "anotherUser"
+        };
+        var activeSell = new BuySell
+        {
+            BuySellId = 303, SessionId = sessionId, SellerUserId = userId, BuyerUserId = null,
+            TeamAssignment = TeamAssignment.TBD, CreateDateTime = DateTime.UtcNow,
+            UpdateDateTime = DateTime.UtcNow, Seller = user, Session = CreateTestSession(sessionId),
+            CreateByUserId = userId, UpdateByUserId = userId
+        };
+        _mockBuySellRepository.SetupSequence(x => x.GetUserBuySellsAsync(sessionId, userId))
+            .ReturnsAsync(new List<BuySell>())
+            .ReturnsAsync(new List<BuySell> { otherUserSell, activeSell });
+
+        var result = await _buySellService.ProcessSellRequestAsync(userId, new SellRequest { SessionId = sessionId, Note = "test" });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Message.Should().Be("You already have an active Sell for this session");
+    }
 }
 #pragma warning restore IDE0045 // Convert to conditional expression

--- a/HockeyPickup.Api/Services/BuySellService.cs
+++ b/HockeyPickup.Api/Services/BuySellService.cs
@@ -92,6 +92,17 @@ public class BuySellService : IBuySellService
                 var session = await _sessionRepository.GetSessionAsync(request.SessionId);
                 var buyer = await _userManager.FindByIdAsync(userId);
 
+                // Re-validate state-dependent conditions inside the lock to close the TOCTOU gap:
+                // two concurrent requests from the same user can both pass CanBuyAsync before either
+                // writes anything, then enter here sequentially and both create records.
+                var userBuySellsReCheck = await _buySellRepository.GetUserBuySellsAsync(request.SessionId, userId);
+                if (userBuySellsReCheck.Any(t => t.BuyerUserId == userId && t.SellerUserId == null))
+                    return ServiceResult<BuySellResponse>.CreateFailure("You already have an active Buy for this session");
+                if (userBuySellsReCheck.Any(t => t.SellerUserId == userId && t.BuyerUserId == null))
+                    return ServiceResult<BuySellResponse>.CreateFailure("You have an active Sell for this session");
+                if (session.CurrentRosters?.Any(r => r.UserId == userId && r.IsPlaying) == true)
+                    return ServiceResult<BuySellResponse>.CreateFailure("You are already on the roster for this session");
+
                 // Look for matching sell BuySells
                 var matchingSell = await _buySellRepository.FindMatchingSellBuySellAsync(request.SessionId);
 
@@ -208,6 +219,15 @@ public class BuySellService : IBuySellService
                 {
                     return ServiceResult<BuySellResponse>.CreateFailure("Seller not found in session roster");
                 }
+
+                // Re-validate state-dependent conditions inside the lock to close the TOCTOU gap:
+                // two concurrent requests from the same user can both pass CanSellAsync before either
+                // writes anything, then enter here sequentially and both create records.
+                var userBuySellsReCheck = await _buySellRepository.GetUserBuySellsAsync(request.SessionId, userId);
+                if (userBuySellsReCheck.Any(t => t.BuyerUserId == userId && t.SellerUserId == null))
+                    return ServiceResult<BuySellResponse>.CreateFailure("You have an active Buy for this session");
+                if (userBuySellsReCheck.Any(t => t.SellerUserId == userId && t.BuyerUserId == null))
+                    return ServiceResult<BuySellResponse>.CreateFailure("You already have an active Sell for this session");
 
                 // Look for matching buy BuySells
                 var matchingBuy = await _buySellRepository.FindMatchingBuyBuySellAsync(request.SessionId);

--- a/HockeyPickup.Api/Services/BuySellService.cs
+++ b/HockeyPickup.Api/Services/BuySellService.cs
@@ -5,6 +5,7 @@ using HockeyPickup.Api.Models.Domain;
 using HockeyPickup.Api.Models.Requests;
 using HockeyPickup.Api.Models.Responses;
 using Microsoft.AspNetCore.Identity;
+using System.Collections.Concurrent;
 
 namespace HockeyPickup.Api.Services;
 
@@ -35,6 +36,10 @@ public class BuySellService : IBuySellService
     private readonly ILogger<BuySellService> _logger;
     private readonly ISubscriptionHandler _subscriptionHandler;
     private readonly IUserRepository _userRepository;
+    private static readonly ConcurrentDictionary<int, SemaphoreSlim> _sessionBuySellLocks = new();
+
+    private static SemaphoreSlim GetSessionBuySellLock(int sessionId)
+        => _sessionBuySellLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
 
     public BuySellService(
         UserManager<AspNetUser> userManager,
@@ -77,75 +82,87 @@ public class BuySellService : IBuySellService
             // - User exists and is allowed to buy
             // - Buy window is open
             // - No conflicting BuySells exist
-            var session = await _sessionRepository.GetSessionAsync(request.SessionId);
-            var buyer = await _userManager.FindByIdAsync(userId);
 
-            // Look for matching sell BuySells
-            var matchingSell = await _buySellRepository.FindMatchingSellBuySellAsync(request.SessionId);
-
-            BuySell buySell, result;
-            string message;
-
-            if (matchingSell != null)
+            // Acquire a per-session lock so concurrent buy requests cannot simultaneously claim
+            // the same pending sell record, which would corrupt roster state.
+            var sessionLock = GetSessionBuySellLock(request.SessionId);
+            await sessionLock.WaitAsync();
+            try
             {
-                // Get seller's details for team assignment
-                var seller = await _userManager.FindByIdAsync(matchingSell.SellerUserId);
-                if (seller == null)
-                    return ServiceResult<BuySellResponse>.CreateFailure("Seller not found");
+                var session = await _sessionRepository.GetSessionAsync(request.SessionId);
+                var buyer = await _userManager.FindByIdAsync(userId);
 
-                // Get seller's current roster entry to determine team
-                var sellerRoster = session.CurrentRosters?.FirstOrDefault(r => r.UserId == seller.Id);
-                if (sellerRoster == null)
-                    return ServiceResult<BuySellResponse>.CreateFailure("Seller not found in session roster");
+                // Look for matching sell BuySells
+                var matchingSell = await _buySellRepository.FindMatchingSellBuySellAsync(request.SessionId);
 
-                // Matched with existing sell BuySell
-                buySell = matchingSell;
-                buySell.BuyerUserId = userId;
-                buySell.UpdateByUserId = userId;
-                buySell.UpdateDateTime = DateTime.UtcNow;
-                buySell.BuyerNote = request.Note;
+                BuySell buySell, result;
+                string message;
 
-                message = $"{buyer.FirstName} {buyer.LastName} BOUGHT spot from seller: {matchingSell.Seller.FirstName} {matchingSell.Seller.LastName}. Team Assignment: {matchingSell.TeamAssignment}";
-
-                result = await _buySellRepository.UpdateBuySellAsync(buySell, message);
-
-                // Add buyer as playing to SessionRoster
-                session = await _sessionRepository.AddOrUpdatePlayerToRosterAsync(request.SessionId, buySell.BuyerUserId, sellerRoster.TeamAssignment, buyer.PositionPreference, buySell.BuySellId);
-
-                // Send a message to Service Bus that a player bought their spot from a seller
-                await SendBuySellServiceBusCommsMessageAsync("BoughtSpotFromSeller", session.SessionId, session.SessionDate, buyer, seller, matchingSell.TeamAssignment);
-            }
-            else
-            {
-                // Create new buy BuySell
-                buySell = new BuySell
+                if (matchingSell != null)
                 {
-                    SessionId = request.SessionId,
-                    BuyerUserId = userId,
-                    TeamAssignment = TeamAssignment.TBD,
-                    CreateByUserId = userId,
-                    UpdateByUserId = userId,
-                    CreateDateTime = DateTime.UtcNow,
-                    UpdateDateTime = DateTime.UtcNow,
-                    BuyerNote = request.Note,
-                    Price = session.Cost,
-                    Buyer = buyer,
-                    PaymentSent = false,
-                    PaymentReceived = false,
-                    SellerNoteFlagged = false,
-                    BuyerNoteFlagged = false,
-                    PaymentMethod = null
-                };
+                    // Get seller's details for team assignment
+                    var seller = await _userManager.FindByIdAsync(matchingSell.SellerUserId);
+                    if (seller == null)
+                        return ServiceResult<BuySellResponse>.CreateFailure("Seller not found");
 
-                message = $"{buyer.FirstName} {buyer.LastName} added to BUYING queue";
+                    // Get seller's current roster entry to determine team
+                    var sellerRoster = session.CurrentRosters?.FirstOrDefault(r => r.UserId == seller.Id);
+                    if (sellerRoster == null)
+                        return ServiceResult<BuySellResponse>.CreateFailure("Seller not found in session roster");
 
-                result = await _buySellRepository.CreateBuySellAsync(buySell, message);
+                    // Matched with existing sell BuySell
+                    buySell = matchingSell;
+                    buySell.BuyerUserId = userId;
+                    buySell.UpdateByUserId = userId;
+                    buySell.UpdateDateTime = DateTime.UtcNow;
+                    buySell.BuyerNote = request.Note;
 
-                // Send a message to Service Bus that a player added themselves to buyer queue
-                await SendBuySellServiceBusCommsMessageAsync("AddedToBuyQueue", session.SessionId, session.SessionDate, buyer, null, null);
+                    message = $"{buyer.FirstName} {buyer.LastName} BOUGHT spot from seller: {matchingSell.Seller.FirstName} {matchingSell.Seller.LastName}. Team Assignment: {matchingSell.TeamAssignment}";
+
+                    result = await _buySellRepository.UpdateBuySellAsync(buySell, message);
+
+                    // Add buyer as playing to SessionRoster
+                    session = await _sessionRepository.AddOrUpdatePlayerToRosterAsync(request.SessionId, buySell.BuyerUserId, sellerRoster.TeamAssignment, buyer.PositionPreference, buySell.BuySellId);
+
+                    // Send a message to Service Bus that a player bought their spot from a seller
+                    await SendBuySellServiceBusCommsMessageAsync("BoughtSpotFromSeller", session.SessionId, session.SessionDate, buyer, seller, matchingSell.TeamAssignment);
+                }
+                else
+                {
+                    // Create new buy BuySell
+                    buySell = new BuySell
+                    {
+                        SessionId = request.SessionId,
+                        BuyerUserId = userId,
+                        TeamAssignment = TeamAssignment.TBD,
+                        CreateByUserId = userId,
+                        UpdateByUserId = userId,
+                        CreateDateTime = DateTime.UtcNow,
+                        UpdateDateTime = DateTime.UtcNow,
+                        BuyerNote = request.Note,
+                        Price = session.Cost,
+                        Buyer = buyer,
+                        PaymentSent = false,
+                        PaymentReceived = false,
+                        SellerNoteFlagged = false,
+                        BuyerNoteFlagged = false,
+                        PaymentMethod = null
+                    };
+
+                    message = $"{buyer.FirstName} {buyer.LastName} added to BUYING queue";
+
+                    result = await _buySellRepository.CreateBuySellAsync(buySell, message);
+
+                    // Send a message to Service Bus that a player added themselves to buyer queue
+                    await SendBuySellServiceBusCommsMessageAsync("AddedToBuyQueue", session.SessionId, session.SessionDate, buyer, null, null);
+                }
+
+                return ServiceResult<BuySellResponse>.CreateSuccess(await MapBuySellToResponse(result), message);
             }
-
-            return ServiceResult<BuySellResponse>.CreateSuccess(await MapBuySellToResponse(result), message);
+            finally
+            {
+                sessionLock.Release();
+            }
         }
         catch (Exception ex)
         {
@@ -175,79 +192,91 @@ public class BuySellService : IBuySellService
             // - Session exists and is valid
             // - User exists and is on the roster
             // - No conflicting BuySells exist
-            var session = await _sessionRepository.GetSessionAsync(request.SessionId);
-            var seller = await _userManager.FindByIdAsync(userId);
 
-            // Get seller's current roster entry to determine team
-            var sellerRoster = session.CurrentRosters?.FirstOrDefault(r => r.UserId == userId);
-            if (sellerRoster == null)
+            // Acquire a per-session lock so concurrent sell requests cannot simultaneously claim
+            // the same pending buy record, which would corrupt roster state.
+            var sessionLock = GetSessionBuySellLock(request.SessionId);
+            await sessionLock.WaitAsync();
+            try
             {
-                return ServiceResult<BuySellResponse>.CreateFailure("Seller not found in session roster");
-            }
+                var session = await _sessionRepository.GetSessionAsync(request.SessionId);
+                var seller = await _userManager.FindByIdAsync(userId);
 
-            // Look for matching buy BuySells
-            var matchingBuy = await _buySellRepository.FindMatchingBuyBuySellAsync(request.SessionId);
-
-            BuySell buySell, result;
-            string message;
-
-            if (matchingBuy != null)
-            {
-                // Matched with existing buy BuySell
-                buySell = matchingBuy;
-                buySell.SellerUserId = userId;
-                buySell.UpdateByUserId = userId;
-                buySell.UpdateDateTime = DateTime.UtcNow;
-                buySell.TeamAssignment = sellerRoster.TeamAssignment;
-                buySell.SellerNote = request.Note;
-
-                message = $"{seller.FirstName} {seller.LastName} SOLD spot to buyer: {matchingBuy.Buyer.FirstName} {matchingBuy.Buyer.LastName}. Team Assignment: {matchingBuy.TeamAssignment}";
-
-                result = await _buySellRepository.UpdateBuySellAsync(buySell, message);
-
-                // Update SessionRoster to mark seller as not playing
-                session = await _sessionRepository.UpdatePlayerStatusAsync(request.SessionId, userId, false, DateTime.UtcNow, result.BuySellId);
-
-                // Add buyer as playing to SessionRoster
-                session = await _sessionRepository.AddOrUpdatePlayerToRosterAsync(request.SessionId, buySell.BuyerUserId, sellerRoster.TeamAssignment, buySell.Buyer.PositionPreference, buySell.BuySellId);
-
-                // Send a message to Service Bus that a player sold their spot to a buyer
-                await SendBuySellServiceBusCommsMessageAsync("SoldSpotToBuyer", session.SessionId, session.SessionDate, buySell.Buyer, seller, matchingBuy.TeamAssignment);
-            }
-            else
-            {
-                // Create new sell BuySell
-                buySell = new BuySell
+                // Get seller's current roster entry to determine team
+                var sellerRoster = session.CurrentRosters?.FirstOrDefault(r => r.UserId == userId);
+                if (sellerRoster == null)
                 {
-                    SessionId = request.SessionId,
-                    SellerUserId = userId,
-                    CreateByUserId = userId,
-                    UpdateByUserId = userId,
-                    CreateDateTime = DateTime.UtcNow,
-                    UpdateDateTime = DateTime.UtcNow,
-                    SellerNote = request.Note,
-                    Price = session.Cost,
-                    TeamAssignment = sellerRoster.TeamAssignment,
-                    Seller = seller,
-                    PaymentSent = false,
-                    PaymentReceived = false,
-                    SellerNoteFlagged = false,
-                    BuyerNoteFlagged = false,
-                    PaymentMethod = null
-                };
+                    return ServiceResult<BuySellResponse>.CreateFailure("Seller not found in session roster");
+                }
 
-                message = $"{seller.FirstName} {seller.LastName} added to SELLING queue";
+                // Look for matching buy BuySells
+                var matchingBuy = await _buySellRepository.FindMatchingBuyBuySellAsync(request.SessionId);
 
-                result = await _buySellRepository.CreateBuySellAsync(buySell, message);
+                BuySell buySell, result;
+                string message;
 
-                // Update SessionRoster to mark seller as not playing
-                session = await _sessionRepository.UpdatePlayerStatusAsync(request.SessionId, userId, false, DateTime.UtcNow, result.BuySellId);
+                if (matchingBuy != null)
+                {
+                    // Matched with existing buy BuySell
+                    buySell = matchingBuy;
+                    buySell.SellerUserId = userId;
+                    buySell.UpdateByUserId = userId;
+                    buySell.UpdateDateTime = DateTime.UtcNow;
+                    buySell.TeamAssignment = sellerRoster.TeamAssignment;
+                    buySell.SellerNote = request.Note;
 
-                // Send a message to Service Bus that a player added themselves to selling queue
-                await SendBuySellServiceBusCommsMessageAsync("AddedToSellQueue", session.SessionId, session.SessionDate, null, seller, null);
+                    message = $"{seller.FirstName} {seller.LastName} SOLD spot to buyer: {matchingBuy.Buyer.FirstName} {matchingBuy.Buyer.LastName}. Team Assignment: {matchingBuy.TeamAssignment}";
+
+                    result = await _buySellRepository.UpdateBuySellAsync(buySell, message);
+
+                    // Update SessionRoster to mark seller as not playing
+                    session = await _sessionRepository.UpdatePlayerStatusAsync(request.SessionId, userId, false, DateTime.UtcNow, result.BuySellId);
+
+                    // Add buyer as playing to SessionRoster
+                    session = await _sessionRepository.AddOrUpdatePlayerToRosterAsync(request.SessionId, buySell.BuyerUserId, sellerRoster.TeamAssignment, buySell.Buyer.PositionPreference, buySell.BuySellId);
+
+                    // Send a message to Service Bus that a player sold their spot to a buyer
+                    await SendBuySellServiceBusCommsMessageAsync("SoldSpotToBuyer", session.SessionId, session.SessionDate, buySell.Buyer, seller, matchingBuy.TeamAssignment);
+                }
+                else
+                {
+                    // Create new sell BuySell
+                    buySell = new BuySell
+                    {
+                        SessionId = request.SessionId,
+                        SellerUserId = userId,
+                        CreateByUserId = userId,
+                        UpdateByUserId = userId,
+                        CreateDateTime = DateTime.UtcNow,
+                        UpdateDateTime = DateTime.UtcNow,
+                        SellerNote = request.Note,
+                        Price = session.Cost,
+                        TeamAssignment = sellerRoster.TeamAssignment,
+                        Seller = seller,
+                        PaymentSent = false,
+                        PaymentReceived = false,
+                        SellerNoteFlagged = false,
+                        BuyerNoteFlagged = false,
+                        PaymentMethod = null
+                    };
+
+                    message = $"{seller.FirstName} {seller.LastName} added to SELLING queue";
+
+                    result = await _buySellRepository.CreateBuySellAsync(buySell, message);
+
+                    // Update SessionRoster to mark seller as not playing
+                    session = await _sessionRepository.UpdatePlayerStatusAsync(request.SessionId, userId, false, DateTime.UtcNow, result.BuySellId);
+
+                    // Send a message to Service Bus that a player added themselves to selling queue
+                    await SendBuySellServiceBusCommsMessageAsync("AddedToSellQueue", session.SessionId, session.SessionDate, null, seller, null);
+                }
+
+                return ServiceResult<BuySellResponse>.CreateSuccess(await MapBuySellToResponse(result), message);
             }
-
-            return ServiceResult<BuySellResponse>.CreateSuccess(await MapBuySellToResponse(result), message);
+            finally
+            {
+                sessionLock.Release();
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new in-process per-session locking mechanism and additional inside-lock validation in core buy/sell flows, which could affect throughput and introduce locking edge cases if misused. Changes are covered by new concurrency/TOCTOU-focused tests, reducing regression risk.
> 
> **Overview**
> Prevents concurrent `ProcessBuyRequestAsync`/`ProcessSellRequestAsync` calls for the same session from double-claiming the same pending buy/sell record by introducing a per-session `SemaphoreSlim` stored in a static `ConcurrentDictionary`.
> 
> Adds inside-lock rechecks to close TOCTOU gaps (duplicate active buy/sell and roster state changes) and expands the test suite with concurrent-buyer/concurrent-seller and TOCTOU regression tests to verify only one match is claimed while the other request queues or fails appropriately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd94c27330cff3e763182a9e48ca6dd076b22e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->